### PR TITLE
description element added to ensure phonegap build compliance

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -4,6 +4,7 @@
            id="com.bluefletch.motorola"
       version="0.1.0">
     <name>Motorola Cordova Plugin</name>
+	<description>Motorola Cordova Plugin</description>
 
 
     <js-module src="www/datawedge.js" name="MotorolaDataWedge">


### PR DESCRIPTION
If no "description" element is available phonegap build does not allow to enable this plugin for build.