### PR TITLE
Add Android namespace to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+xmlns:android="http://schemas.android.com/apk/res/android"
            id="com.bluefletch.motorola"
       version="0.1.0">
     <name>Motorola Cordova Plugin</name>


### PR DESCRIPTION
I'm currently using the Telerik Platform to develop Cordova apps, and the XML parser was throwing errors when I tried to import this plugin due to the Android namespace not being defined. The [sample XML in the plugin spec](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html) also seems to have this line included, so I think it's probably a good idea to do so.