### PR TITLE
added xmlns:android to plugin.xml to support VS2015

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+           xmlns:android="http://schemas.android.com/apk/res/android"
            id="com.bluefletch.motorola"
       version="0.1.0">
     <name>Motorola Cordova Plugin</name>


### PR DESCRIPTION
I found that this change is required in order for Visual Studio 2015 plugin manager to install this plugin.