### PR TITLE
Change handleIntent to check if equal to dataWedgeAction

### DIFF
--- a/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
+++ b/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
@@ -127,7 +127,7 @@ public class DataWedgeIntentHandler {
     public void handleIntent(Intent intent){
         if (intent != null) {
 			String action = intent.getAction();
-			if(action != null && action.equals(DEFAULT_ACTION)) {
+			if(action != null && action.equals(dataWedgeAction)) {
 				dataReceiver.onReceive(applicationContext, intent);
 			}
         }


### PR DESCRIPTION
In DataWedgeIntentHandler.handleIntent() there is a check, if the intents action name equals to DEFAULT_ACTION.
So the intent never gets handled if an custom action name is defined.