### PR TITLE
Support for 'Zebra' devices

### DIFF
--- a/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
+++ b/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
@@ -112,7 +112,7 @@ public class DataWedgeIntentHandler {
     }
 
     protected void enableScanner(boolean shouldEnable) {
-        Intent enableIntent = new Intent(dataWedgeBaseUri + dataWedgeBaseUri + ".api.ACTION_SCANNERINPUTPLUGIN");
+        Intent enableIntent = new Intent(dataWedgeBaseUri + ".api.ACTION_SCANNERINPUTPLUGIN");
         enableIntent.putExtra(dataWedgeBaseUri + ".api.EXTRA_PARAMETER", 
             shouldEnable ? "ENABLE_PLUGIN" : "DISABLE_PLUGIN");
 

--- a/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
+++ b/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
@@ -127,7 +127,7 @@ public class DataWedgeIntentHandler {
     public void handleIntent(Intent intent){
         if (intent != null) {
 			String action = intent.getAction();
-			if(action != null && action.equals(DEFAULT_ACTION)) {
+			if(action != null && action.equals(dataWedgeAction)) {
 				dataReceiver.onReceive(applicationContext, intent);
 			}
         }

--- a/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
+++ b/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
@@ -25,8 +25,8 @@ public class DataWedgeIntentHandler {
 
     protected Context applicationContext;
 
-    protected String dataWedgeBaseUri = dataWedgeBaseUri + "";
-    
+    protected String dataWedgeBaseUri = "com.bluefletch.motorola.datawedge";
+
     protected static String DEFAULT_ACTION = "com.bluefletch.motorola.datawedge.ACTION";
     protected String dataWedgeAction = DEFAULT_ACTION;
     
@@ -55,6 +55,14 @@ public class DataWedgeIntentHandler {
     public DataWedgeIntentHandler(Context context) {
         TAG = this.getClass().getSimpleName();
         applicationContext = context;
+    }
+
+    public DataWedgeIntentHandler(Context context, String dataWedgeBaseUri) {
+        TAG = this.getClass().getSimpleName();
+        applicationContext = context;
+        this.dataWedgeBaseUri = dataWedgeBaseUri;
+        TRACK_PREFIX_FORMAT = dataWedgeBaseUri + ".msr_track%d";
+        TRACK_STATUS_FORMAT = dataWedgeBaseUri + ".msr_track%d_status";
     }
 
     public void start() {
@@ -139,8 +147,8 @@ public class DataWedgeIntentHandler {
         }
     }
 
-    private static String TRACK_PREFIX_FORMAT = dataWedgeBaseUri + ".msr_track%d";
-    private static String TRACK_STATUS_FORMAT = dataWedgeBaseUri + ".msr_track%d_status";
+    private static String TRACK_PREFIX_FORMAT = "com.bluefletch.motorola.datawedge.msr_track%d";
+    private static String TRACK_STATUS_FORMAT = "com.bluefletch.motorola.datawedge.msr_track%d_status";
     /**
      * Receiver to handle receiving data from intents
      */

--- a/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
+++ b/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
@@ -25,8 +25,11 @@ public class DataWedgeIntentHandler {
 
     protected Context applicationContext;
 
+    protected String dataWedgeBaseUri = dataWedgeBaseUri + "";
+    
     protected static String DEFAULT_ACTION = "com.bluefletch.motorola.datawedge.ACTION";
     protected String dataWedgeAction = DEFAULT_ACTION;
+    
     /**
     * This function must be called with the intent Action as configured in the DataWedge Application
     **/
@@ -36,6 +39,9 @@ public class DataWedgeIntentHandler {
         this.dataWedgeAction = action;
     }
 
+    public void setDataWedgeBaseUri(String baseUri) {
+        this.dataWedgeBaseUri = baseUri;
+    }
     protected ScanCallback<BarcodeScan> scanCallback;
     public void setScanCallback(ScanCallback<BarcodeScan> callback){
         scanCallback = callback;
@@ -98,8 +104,8 @@ public class DataWedgeIntentHandler {
     }
 
     protected void enableScanner(boolean shouldEnable) {
-        Intent enableIntent = new Intent("com.motorolasolutions.emdk.datawedge.api.ACTION_SCANNERINPUTPLUGIN");
-        enableIntent.putExtra("com.motorolasolutions.emdk.datawedge.api.EXTRA_PARAMETER", 
+        Intent enableIntent = new Intent(dataWedgeBaseUri + dataWedgeBaseUri + ".api.ACTION_SCANNERINPUTPLUGIN");
+        enableIntent.putExtra(dataWedgeBaseUri + ".api.EXTRA_PARAMETER", 
             shouldEnable ? "ENABLE_PLUGIN" : "DISABLE_PLUGIN");
 
         applicationContext.sendBroadcast(enableIntent);
@@ -107,8 +113,8 @@ public class DataWedgeIntentHandler {
 
     public void startScanning(boolean turnOn) {
         synchronized (stateLock) {
-            Intent scanOnIntent = new Intent("com.motorolasolutions.emdk.datawedge.api.ACTION_SOFTSCANTRIGGER");
-            scanOnIntent.putExtra("com.motorolasolutions.emdk.datawedge.api.EXTRA_PARAMETER", 
+            Intent scanOnIntent = new Intent(dataWedgeBaseUri + ".api.ACTION_SOFTSCANTRIGGER");
+            scanOnIntent.putExtra(dataWedgeBaseUri + ".api.EXTRA_PARAMETER", 
                 turnOn ? "START_SCANNING" : "STOP_SCANNING");
 
             applicationContext.sendBroadcast(scanOnIntent);
@@ -117,8 +123,8 @@ public class DataWedgeIntentHandler {
 
     public void switchProfile(String profile) {
         synchronized (stateLock) {
-            Intent profileIntent = new Intent("com.motorolasolutions.emdk.datawedge.api.ACTION_SETDEFAULTPROFILE");
-            profileIntent.putExtra("com.motorolasolutions.emdk.datawedge.api.EXTRA_PROFILENAME", profile);
+            Intent profileIntent = new Intent(dataWedgeBaseUri + ".api.ACTION_SETDEFAULTPROFILE");
+            profileIntent.putExtra(dataWedgeBaseUri + ".api.EXTRA_PROFILENAME", profile);
 
             applicationContext.sendBroadcast(profileIntent);
         }
@@ -133,8 +139,8 @@ public class DataWedgeIntentHandler {
         }
     }
 
-    private static String TRACK_PREFIX_FORMAT = "com.motorolasolutions.emdk.datawedge.msr_track%d";
-    private static String TRACK_STATUS_FORMAT = "com.motorolasolutions.emdk.datawedge.msr_track%d_status";
+    private static String TRACK_PREFIX_FORMAT = dataWedgeBaseUri + ".msr_track%d";
+    private static String TRACK_STATUS_FORMAT = dataWedgeBaseUri + ".msr_track%d_status";
     /**
      * Receiver to handle receiving data from intents
      */
@@ -143,13 +149,13 @@ public class DataWedgeIntentHandler {
         public void onReceive(Context context, Intent intent) {
             Log.i(TAG, "Data receiver trigged");
             try {
-                if("scanner".equalsIgnoreCase(intent.getStringExtra("com.motorolasolutions.emdk.datawedge.source"))) {
+                if("scanner".equalsIgnoreCase(intent.getStringExtra(dataWedgeBaseUri + ".source"))) {
                     if (scanCallback == null) {
                         Log.e(TAG, "Scan data received, but callback is null.");
                         return;
                     }
-                    String barcode = intent.getStringExtra("com.motorolasolutions.emdk.datawedge.data_string");
-                    String labelType = intent.getStringExtra("com.motorolasolutions.emdk.datawedge.label_type");
+                    String barcode = intent.getStringExtra(dataWedgeBaseUri + ".data_string");
+                    String labelType = intent.getStringExtra(dataWedgeBaseUri + ".label_type");
 
                     scanCallback.execute(new BarcodeScan(labelType, barcode));
                 } else {

--- a/src/android/com/bluefletch/motorola/plugin/MotorolaDatawedgePlugin.java
+++ b/src/android/com/bluefletch/motorola/plugin/MotorolaDatawedgePlugin.java
@@ -104,6 +104,10 @@ public class MotorolaDatawedgePlugin extends CordovaPlugin {
             wedge.stop();
         }
 
+        else if ("isZebra".equals(action)){
+            wedge.setDataWedgeBaseUri("com.symbol.datawedge");
+        }
+
 
         //start plugin now if not already started
         if ("start".equals(action) || "magstripe.register".equals(action) || "scanner.register".equals(action)) {

--- a/src/android/com/bluefletch/motorola/plugin/MotorolaDatawedgePlugin.java
+++ b/src/android/com/bluefletch/motorola/plugin/MotorolaDatawedgePlugin.java
@@ -30,12 +30,18 @@ public class MotorolaDatawedgePlugin extends CordovaPlugin {
     
     private DataWedgeIntentHandler wedge;
     protected static String TAG = "MotorolaDatawedgePlugin";
+    protected static String META_DATA_BASEURI = "com.bluefletch.motorola.datawedge.BASEURI";
 
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView)
     {
         super.initialize(cordova, webView);
-        wedge = new DataWedgeIntentHandler(cordova.getActivity().getBaseContext());
+        String value = MotorolaDatawedgePlugin.getAppSource(cordova.getActivity().getBaseContext(), META_DATA_BASEURI);
+        if (value != null && !"".equals(value)) {
+            wedge = new DataWedgeIntentHandler(cordova.getActivity().getBaseContext(), value);
+        } else {
+            wedge = new DataWedgeIntentHandler(cordova.getActivity().getBaseContext());
+        }
     }
     @Override
     public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -152,5 +158,26 @@ public class MotorolaDatawedgePlugin extends CordovaPlugin {
     {
         super.onResume(multitasking);
         wedge.start();
+    }
+
+    /**
+     * @param context eg. cordova.getActivity().getBaseContext()
+     * @param metaName eg. "com.bluefletch.motorola.datawedge.baseuri"
+     * @return the meta-data value as String
+     */
+    public static String getAppSource(Context context, String metaName) {
+        String result = null;
+        try {
+            ApplicationInfo appInfo = context.getPackageManager()
+                    .getApplicationInfo(context.getPackageName(),
+                            PackageManager.GET_META_DATA);
+            if (appInfo.metaData != null) {
+                result = appInfo.metaData.getString(metaName);
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+            Log.i(TAG, e.toString());
+        }
+        return result;
     }
 }

--- a/src/android/com/bluefletch/motorola/plugin/MotorolaDatawedgePlugin.java
+++ b/src/android/com/bluefletch/motorola/plugin/MotorolaDatawedgePlugin.java
@@ -4,6 +4,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.util.Log;
 
 

--- a/www/datawedge.js
+++ b/www/datawedge.js
@@ -91,6 +91,9 @@ DataWedge.prototype.stopScanner = function () {
     exec(null, null, 'MotorolaDataWedge', 'scanner.softScanOff', []);
 };
 
+
+
+
 //create instance
 var DataWedge = new DataWedge();
 

--- a/www/datawedge.js
+++ b/www/datawedge.js
@@ -91,6 +91,13 @@ DataWedge.prototype.stopScanner = function () {
     exec(null, null, 'MotorolaDataWedge', 'scanner.softScanOff', []);
 };
 
+/**
+ * Manually turn off barcode scanner
+ */
+DataWedge.prototype.isZebra = function () {
+    exec(null, null, 'MotorolaDataWedge', 'scanner.isZebra', []);
+};
+
 
 
 

--- a/www/datawedge.js
+++ b/www/datawedge.js
@@ -91,16 +91,6 @@ DataWedge.prototype.stopScanner = function () {
     exec(null, null, 'MotorolaDataWedge', 'scanner.softScanOff', []);
 };
 
-/**
- * Manually turn off barcode scanner
- */
-DataWedge.prototype.isZebra = function () {
-    exec(null, null, 'MotorolaDataWedge', 'scanner.isZebra', []);
-};
-
-
-
-
 //create instance
 var DataWedge = new DataWedge();
 


### PR DESCRIPTION
## Reason
Devices of the brand 'Zebra' somehow use a slightly different DataWedge-API.
So, if an incoming intent gets triggered, nothing will happen – especially in _DataWedgeIntentHandler.dataReceiver()_. However the _start()_ and _stop()_ functions are working.

## Fix
I’ve added an check in the overridden _initialize()_ function of the _DataWedgeIntentHandler_. It’s now possible to add an _<meta-data>_ Tag in the Android-Manifest which specifies the bas URI of the DataWedge app.

### Code Sample
AndroidManifest.xml
```xml
<?xml [...]?>
<manifest [...]>
    <application [...]>
        [...]
        <meta-data android:name="com.bluefletch.motorola.datawedge.BASEURI" android:value="com.symbol.datawedge" />
    </application>
    [...]
</manifest>
```
## Sources
[Zebra DataWedge-API](http://techdocs.zebra.com/datawedge/6-3/guide/api/overview/)
[Zebra DataWedge Doc](http://techdocs.zebra.com/datawedge/7-3/guide/about/)

---
Appx.: Thanks for the plugin, thats some nice work!
Let me know if I can help you any futher.

