### PR TITLE
Fixed the registerReceiver for Android 14+

### DIFF
--- a/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
+++ b/lib/android/com/bluefletch/motorola/DataWedgeIntentHandler.java
@@ -63,7 +63,7 @@ public class DataWedgeIntentHandler {
 
             Log.i(TAG, "Register for Datawedge intent: " + dataWedgeAction);
 
-            applicationContext.registerReceiver(dataReceiver, new IntentFilter(dataWedgeAction));
+            applicationContext.registerReceiver(dataReceiver, new IntentFilter(dataWedgeAction), applicationContext.RECEIVER_EXPORTED);
 
             enableScanner(true);
             hasInitialized = true;


### PR DESCRIPTION
This PR fixes a crash on Android 14 caused by stricter broadcast receiver requirements.
Android 14 now mandates that dynamically registered receivers explicitly specify whether they are exported or not. The previous implementation triggered a SecurityException when receiving DataWedge intents.

The fix adds the required flag: RECEIVER_EXPORTED.
This resolves the crash on Android 14 while maintaining compatibility with earlier Android versions.

